### PR TITLE
Added dataTypes standard

### DIFF
--- a/standards_and_profiles/dataTypes.py
+++ b/standards_and_profiles/dataTypes.py
@@ -1,0 +1,20 @@
+# setup
+def addTypeTags(dta):
+    dta.tag.update({"dataType": ""})
+    return dta
+
+
+# use the following or just do dta.tag["dataType"] = <string>
+def setType(dta, dataType):
+    dta.tag["dataType"] = str(dataType)
+    return dta
+
+
+def removeTypeTags(dta):
+    dta.tag.pop("dataType")
+    return dta
+
+
+# runtime
+if __name__ == "__main__":
+    print("data types tags v10.0")


### PR DESCRIPTION
data in sysh is pretty genric so heres a way to state what kind of data is in dta.d

just set the "dataType" tag to designate the type of data contined using the setType function or by literly setting it with dta.tag["dataType'] = <string>